### PR TITLE
Trimming whitespace on code-block component so pre behaves correctly

### DIFF
--- a/addon/components/code-block.js
+++ b/addon/components/code-block.js
@@ -6,5 +6,9 @@ export default CodeBase.extend({
 
   getElement() {
     return this.element.querySelector('[class*=language-]');
+  },
+
+  didRender() {
+    this.element.innerHTML = this.element.innerHTML.trim();
   }
 });

--- a/tests/acceptance/code-block-test.js
+++ b/tests/acceptance/code-block-test.js
@@ -12,3 +12,11 @@ test('has `line-numbers` plugin', function(assert) {
     assert.ok(find('pre.code-block .line-numbers-rows'), '`line-numbers` plugin generates `.line-numbers-rows`');
   });
 });
+
+test('the pre innerHTML is trimmed when rendered', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('pre.code-block').innerHTML.split('\n').length, 3);
+  });
+});


### PR DESCRIPTION
Currently the `code-block` component renders the following HTML.

```
<pre><code>this is code</code>
</pre>
```

While this behaves correctly in the default theme, switching to the coy theme (and others, perhaps) causes the newline between the closing `code` and `pre` tags to be visible.

This change trims the `innerHTML` of the `pre` tag, making the resulting HTML look like the following.

```
<pre><code>this is code</code></pre>
```

Thanks for the great work!