### PR TITLE
add embroider scenarios to ember-try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=ember-classic
+    - env: EMBER_TRY_SCENARIO=embroider
+    - env: EMBER_TRY_SCENARIO=embroider-optimized
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -83,7 +83,27 @@ module.exports = async function() {
             edition: 'classic'
           }
         }
-      }
+      },
+      {
+        name: 'embroider',
+        npm: {
+          devDependencies: {
+            '@embroider/core': '*',
+            '@embroider/webpack': '*',
+            '@embroider/compat': '*',
+          },
+        },
+      },
+      {
+        name: 'embroider-optimized',
+        npm: {
+          devDependencies: {
+            '@embroider/core': '*',
+            '@embroider/webpack': '*',
+            '@embroider/compat': '*',
+          },
+        }
+      },
     ]
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -22,5 +22,23 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  // Use embroider if it's present (it can get added by ember-try)
+  if ('@embroider/core' in app.dependencies()) {
+    /* eslint-disable node/no-missing-require, node/no-extraneous-require */
+    const { Webpack } = require('@embroider/webpack');
+    const { compatBuild } = require('@embroider/compat');
+    /* eslint-enable node/no-missing-require, node/no-extraneous-require */
+    let config = {};
+    if (process.env.EMBER_TRY_SCENARIO === 'embroider-optimized') {
+      config = {
+        staticAddonTrees: true,
+        staticAddonTestSupportTrees: true,
+        staticHelpers: true,
+        staticComponents: true,
+      }
+    }
+    return compatBuild(app, Webpack, config);
+  } else {
+    return app.toTree();
+  }
 };


### PR DESCRIPTION
This adds two scenarios. The first will build the dummy app and test suite using embroider in its most-compatible configuration. The second will build the dummy app and test suite using embroider in its most-optimized configuration.

It's helpful for addons to try both, because apps are likely to start with one and migrate toward the other.