### PR TITLE
Use `require.resolve()` to check if Prism plugin files exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var fs = require('fs');
-
 module.exports = {
   name: require('./package').name,
   included() {
@@ -49,10 +47,8 @@ module.exports = {
 
           fileExtensions.forEach((fileExtension) => {
             const nodeAssetsPath = `plugins/${plugin}/prism-${plugin}.${fileExtension}`;
-            const file = `node_modules/prismjs/${nodeAssetsPath}`;
 
-
-            if (fs.existsSync(file)) {
+            if (maybeResolve(`prismjs/${nodeAssetsPath}`)) {
               this.plugins.push(nodeAssetsPath);
             }
           });
@@ -79,6 +75,17 @@ module.exports = {
   }
 };
 
+function maybeResolve(path) {
+  try {
+    return require.resolve(path);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      return null;
+    } else {
+      throw error;
+    }
+  }
+}
 
 // Polyfill [Addon._findHost](https://ember-cli.com/api/classes/Addon.html#method__findHost) for older versions of ember-cli
 function findHost(addon) {


### PR DESCRIPTION
The old approach implied that the filesystem layout of the `node_modules` folder is flat, but this does not necessarily have to be the case. For example, when using pnpm as a package manager, the `prism` package will be resolvable from `ember-prism`, but it will not be at the location that the old approach expects. This commit should fix the problem by relying on the node module resolution algorithm to determine if certain files of the Prism package exist or not.

/cc @rwwagner90 